### PR TITLE
Bump to upstream version v1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG="v1.0.3"
+ARG TAG=v1.1.1
 ARG COMMIT="fc002af57a81855542759d0f77d16dacd7e1aa38"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.14b1
@@ -9,7 +9,7 @@ RUN set -x && \
     apk --no-cache add \
     git \
     make
-ARG TAG
+ARG TAG=v1.1.1
 RUN git clone --depth=1 https://github.com/k8snetworkplumbingwg/ib-sriov-cni
 WORKDIR ib-sriov-cni
 RUN git fetch --all --tags --prune

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORG ?= rancher
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v1.0.3$(BUILD_META)
+TAG := v1.1.1$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version v1.1.1</summary>
            <p>changed lines [1 12] of file &#34;/tmp/updatecli/github/rancher/image-build-ib-sriov-cni/Dockerfile&#34;</p>
            <details>
                <summary>v1.1.1</summary>
                <pre>&#xA;Release published on the 2024-06-06 15:02:25 +0000 UTC at the url https://github.com/k8snetworkplumbingwg/ib-sriov-cni/releases/tag/v1.1.1&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* switch the golangci install method by @SchSeba in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/86&#xD;&#xA;* Tag release images with vX.Y.z tag by @adrianchiris in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/89&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @SchSeba made their first contribution in https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/86&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/ib-sriov-cni/compare/v1.1.0...v1.1.1</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version v1.1.1</summary>
            <p>1 file(s) updated with &#34;TAG := v1.1.1$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

